### PR TITLE
[유저 활동 내역 관리 버그 수정]

### DIFF
--- a/src/main/java/com/example/monew/domain/activity/service/IUserActivityService.java
+++ b/src/main/java/com/example/monew/domain/activity/service/IUserActivityService.java
@@ -64,13 +64,13 @@ public class IUserActivityService implements UserActivityService{
                 .map(articleViewMapper::toDto)
                 .toArray(UserActivityArticleViewDto[]::new);
         UserActivityCommentLikeDto[] commentLikeDtos = commentLikes.stream()
-                .sorted(Comparator.comparing(CommentLikes::getCreatedAt).reversed())
                 .filter(x-> !x.getComment().isDeleted())
+                .sorted(Comparator.comparing(CommentLikes::getCreatedAt).reversed())
                 .map(commentLikeMapper::toDto)
                 .toArray(UserActivityCommentLikeDto[]::new);
         UserActivityCommentDto[] commentDtos = postedComment.stream()
-                .sorted(Comparator.comparing(Comment::getCreatedAt).reversed())
                 .filter(x-> !x.isDeleted())
+                .sorted(Comparator.comparing(Comment::getCreatedAt).reversed())
                 .map(commentMapper::toDto)
                 .toArray(UserActivityCommentDto[]::new);
 


### PR DESCRIPTION
## 🔍 작업 내용
- comment 논리 삭제시 유저 활동 내역도 반영하도록 변경
- 가장 최근 활동이 가장 위 상단에 위치하도록 유저 활동 내역 정렬 구현
## ⚠️ 주의 사항



## 📎 비고
