### PR TITLE
[로그 파일 생성 안되는 버그 해결] 로컬에서 로그 파일 자동 생성 안되는 버그 해결

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -28,6 +28,9 @@ springdoc:
   api-docs:
     path: /api-docs
 
+logging:
+  file:
+    path: logs
 
 decorator:
   datasource:

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -40,6 +40,10 @@ info:
     name: sprintTeam3
     email: genius5375@gmail.com
 
+logging:
+  file:
+    path: /app/logs
+
 management:
   endpoints:
     web:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <springProperty name="LOG_PATH"
+                    source ="logging.file.path"
+                    defaultValue="/app/logs"
+                    />
 
     <!-- 로그 위치 -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
@@ -13,11 +17,11 @@
     </appender>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>/app/logs/.log</file>
+        <file>${LOG_PATH}/.log</file>
 
         <!-- 날짜가 바뀔 때 (자정 기준) 로그 파일 분리 -->
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>/app/logs/app-%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>${LOG_PATH}/app-%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>30</maxHistory>
         </rollingPolicy>
 


### PR DESCRIPTION
## 🔍 작업 내용
- 애플리케이션 실행시 logging file path 변수에 따라 로그 파일 저장 경로 다르도록 변경 
-(로컬일 경우, ./logs 에  저장, 도커의 경우 /app/logs 에 저장)

## ⚠️ 주의 사항



## 📎 비고
