### PR TITLE
[기사관리] 기사의 링크 저장 크기 255에서 500으로 증가

### DIFF
--- a/src/main/java/com/example/monew/domain/article/entity/Article.java
+++ b/src/main/java/com/example/monew/domain/article/entity/Article.java
@@ -24,7 +24,7 @@ public class Article extends BaseCreatableEntity {
     @Column(name="source", nullable = false, updatable = false)
     private String source;
 
-    @Column(name="source_url", nullable = false, updatable = false, unique = true)
+    @Column(name="source_url", nullable = false, updatable = false, unique = true, length = 500)
     private String sourceUrl;
 
     @Column(name="title", nullable = false, updatable = false)


### PR DESCRIPTION
## 🔍 작업 내용


## ⚠️ 주의 사항



## 📎 비고
